### PR TITLE
Fix namespace & Logout method

### DIFF
--- a/modules/Rayium/Auth/Http/Controllers/LogoutController.php
+++ b/modules/Rayium/Auth/Http/Controllers/LogoutController.php
@@ -3,15 +3,16 @@
 namespace modules\Rayium\Auth\Http\Controllers;
 
 use App\Http\Controllers\Controller;
-use Auth;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class LogoutController extends Controller
 {
-    public function logout()
+    public function __invoke(Request $request)
     {
         Auth::logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
         return to_route('login');
     }
-
-
 }

--- a/modules/Rayium/Auth/Routes/auth_routes.php
+++ b/modules/Rayium/Auth/Routes/auth_routes.php
@@ -1,13 +1,8 @@
 <?php
 
+use Illuminate\Support\Facades\Route;
 
-use modules\Rayium\Auth\Http\Controllers\LoginController;
-use modules\Rayium\Auth\Http\Controllers\LogoutController;
-use modules\Rayium\Auth\Http\Controllers\RegisterController;
-use modules\Rayium\Auth\Http\Controllers\ResetController;
-use modules\Rayium\Auth\Http\Controllers\VerifyController;
-
-Route::group(['namespace' => 'Rayium\Auth', 'middleware' => 'web'], function ($router){
+Route::group(['namespace' => 'modules\Rayium\Auth\Http\Controllers', 'middleware' => 'web'], function ($router){
 
     // Register User
 
@@ -35,5 +30,5 @@ Route::group(['namespace' => 'Rayium\Auth', 'middleware' => 'web'], function ($r
 
     // Logout
 
-    $router->get('logout', [LogoutController::class, 'logout'])->name('auth.logout')->middleware('auth');
+    $router->get('logout', LogoutController::class)->name('auth.logout')->middleware('auth');
 });


### PR DESCRIPTION
If you use namespace in `Route::group()` don't add controller namespace in the route file.
like this =>`use modules\Rayium\Auth\Http\Controllers\RegisterController;`

For more security and to prevent [Session Fixation Attack](https://www.google.com/search?client=firefox-b-d&q=Session+Fixation) you should `invalidate` & `regenerate` user token!
FYI, I suggest reading this link [Laravel Doc](https://laravel.com/docs/10.x/session#regenerating-the-session-id)

good luck ✌️